### PR TITLE
unnecessary use in global And Object.assign make your code more clean

### DIFF
--- a/src/components/progress-bar.vue
+++ b/src/components/progress-bar.vue
@@ -49,27 +49,17 @@
       }
     },
     mounted () {
-      this.vueProgress = vueProgress.create({
-        dom: this.$refs.progress,
-        type: this.type,
-        value: this.value,
-        valRate: this.options.valRate,
-        radius: this.options.radius,
-        circleWidth: this.options.circleWidth,
-        varyStrokeArray: this.options.varyStrokeArray,
-        circleLineCap: this.options.circleLineCap,
-        maxValue: this.options.maxValue,
-        text: this.options.text,
-        textColor: this.options.textColor,
-        pathColors: this.options.pathColors,
-        gradientColor: this.options.gradientColor,
-        gradientOpacity: this.options.gradientOpacity,
-        duration: this.options.duration,
-        rectWidth: this.options.rectWidth,
-        rectHeight: this.options.rectHeight,
-        rectRadius: this.options.rectRadius,
-        valAddCalBack: this.valAddCalBack
-      });
+      this.vueProgress = vueProgress.create(
+        Object.assign(
+          {
+            dom: this.$refs.progress,
+            type: this.type,
+            value: this.value,
+            valAddCalBack: this.valAddCalBack
+          },
+          this.options
+        )
+      );      
     }
   }
 </script>

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,5 @@
 import vueProgress from './components/progress-bar.vue'
 
-// expose component to global scope
-if (typeof window !== 'undefined' && window.Vue) {
-  Vue.component('svg-progress-bar', vueProgress)
-}
-
 export { vueProgress }
 
 export default vueProgress


### PR DESCRIPTION
# unnecessary use in globa

You shouldn't force your users use it in global who use `Vue` in global.

And if user use the `Vue` in scope, the code snippet is unuseful.

So,maybe write it in document is more suitable, such as:

use vueProgress in global

```js
Vue.component('svg-progress-bar', vueProgress)
```

or in one component:

```js
export default {
  name: 'admin',
  components: {
    'svg-progress-bar', vueProgress
  },
}
```

# Object.assign make your code more clean

from 

```js
this.vueProgress = vueProgress.create({
  dom: this.$refs.progress,
  type: this.type,
  value: this.value,
  valRate: this.options.valRate,
  radius: this.options.radius,
  circleWidth: this.options.circleWidth,
  varyStrokeArray: this.options.varyStrokeArray,
  circleLineCap: this.options.circleLineCap,
  maxValue: this.options.maxValue,
  text: this.options.text,
  textColor: this.options.textColor,
  pathColors: this.options.pathColors,
  gradientColor: this.options.gradientColor,
  gradientOpacity: this.options.gradientOpacity,
  duration: this.options.duration,
  rectWidth: this.options.rectWidth,
  rectHeight: this.options.rectHeight,
  rectRadius: this.options.rectRadius,
  valAddCalBack: this.valAddCalBack
});
```

to

```js
this.vueProgress = vueProgress.create(
  Object.assign({
      dom: this.$refs.progress,
      type: this.type,
      value: this.value,
      valAddCalBack: this.valAddCalBack
    },
    this.options
  )
);
```